### PR TITLE
quick pass at removing shortname and using collection instead

### DIFF
--- a/config/api_schema.yml
+++ b/config/api_schema.yml
@@ -3,9 +3,9 @@ properties:
     type: keyword
   identifier:
     type: keyword
-  shortname:
-    type: keyword
   collection:
+    type: keyword
+  collection_desc:
     type: keyword
   uri:
     type: keyword

--- a/config/public.yml
+++ b/config/public.yml
@@ -68,7 +68,7 @@ production:
   #   copy over ALL of them to the collection specific config file
   variables_html:
     fig_location: http://cdrhmedia.unl.edu/images/collection
-  variables_search:
+    # collection is passed in automatically as the es_type (or solr_core if no type)
+  variables_solr:
     file_location: http://server.unl.edu/data/collection/
-    collection: Full\ Name\ of\ Collection
-    shortname: short_name
+    # collection is passed in automatically as the solr_core

--- a/scripts/ruby/es_clear_index.rb
+++ b/scripts/ruby/es_clear_index.rb
@@ -5,7 +5,7 @@ require_relative "lib/requirer.rb"
 def confirm_basic(options, url)
   # verify that the user is really sure about the index they're about to wipe
   puts "Are you sure that you want to remove entries from"
-  puts " #{options["shortname"]}'s #{options['environment']} environment?"
+  puts " #{options["es_type"]}'s #{options['environment']} environment?"
   puts "url: #{url}"
   puts "y/N"
   answer = STDIN.gets.chomp
@@ -55,7 +55,7 @@ def clear_all(options)
 end
 
 def clear_index(options)
-  url = "#{options["es_path"]}/#{options["es_index"]}/#{options["shortname"]}/_delete_by_query?pretty"
+  url = "#{options["es_path"]}/#{options["es_index"]}/#{options["es_type"]}/_delete_by_query?pretty"
   confirmation = confirm_basic(options, url)
 
   if confirmation

--- a/scripts/ruby/lib/file_type.rb
+++ b/scripts/ruby/lib/file_type.rb
@@ -21,8 +21,9 @@ class FileType
   def initialize(location, collection_dir, options)
     @file_location = location
     @options = options
-    @options["variables_html"]["collection"] = @options["shortname"]
-    @options["variables_solr"]["collection"] = @options["shortname"]
+    # es_type takes preference as collection name
+    @options["variables_html"]["collection"] = @options["es_type"] || @options["solr_core"]
+    @options["variables_solr"]["collection"] = @options["solr_core"] || @options["collection"]
 
     # set output directories
     @out_es = "#{collection_dir}/output/es"
@@ -42,7 +43,7 @@ class FileType
   def post_es(url=nil)
     url = url || "#{@options["es_path"]}/#{@options["es_index"]}"
     begin
-      transformed = transform_es(@options["output"])
+      transformed = transform_es
     rescue => e
       return { "error" => "Error transforming ES for #{self.filename(false)}: #{e}" }
     end
@@ -112,7 +113,6 @@ class FileType
   end
 
   def transform_html
-    # add html specific variables and shortname as params
     exec_xsl(@file_location, @script_html, "html", @out_html, @options["variables_html"])
   end
 

--- a/scripts/ruby/lib/file_types/file_csv.rb
+++ b/scripts/ruby/lib/file_types/file_csv.rb
@@ -26,11 +26,11 @@ class FileCsv < FileType
   end
 
   def transform_es
-    puts "currently CSV to ES is not supported"
+    raise "Currently CSV to ES transformation is not supported"
   end
 
   def transform_html
-    puts "currently CSV to HTML is not supported"
+    raise "Currently CSV to HTML transformation is not supported"
   end
 
   # I am not sure that this is going to be the best way to set this up

--- a/scripts/ruby/lib/to_es/request.rb
+++ b/scripts/ruby/lib/to_es/request.rb
@@ -38,8 +38,10 @@ class XmlToEs
     @json["category"] = category
     @json["subcategory"] = subcategory
     @json["data_type"] = "tei"
+    # note: collection is typically the es_type
     @json["collection"] = collection
-    @json["shortname"] = shortname
+    # collection_desc is "The Whitman Archive", etc
+    @json["collection_desc"] = collection_desc
     # @json["subject"]
   end
 

--- a/scripts/ruby/lib/to_es/tei_to_es/fields.rb
+++ b/scripts/ruby/lib/to_es/tei_to_es/fields.rb
@@ -35,6 +35,14 @@ class TeiToEs < XmlToEs
     return get_text(@xpaths["creators"])
   end
 
+  def collection
+    @options["es_type"]
+  end
+
+  def collection_desc
+    @options["collection_desc"] || @options["es_type"]
+  end
+
   def contributors
     contribs = []
     @xpaths["contributors"].each do |xpath|
@@ -98,10 +106,6 @@ class TeiToEs < XmlToEs
     return get_list(@xpaths["places"])
   end
 
-  def collection
-    @options["collection_desc"] || @options["collection"]
-  end
-
   def publisher
     get_text(@xpaths["publisher"])
   end
@@ -123,10 +127,6 @@ class TeiToEs < XmlToEs
     # by default collections have no uri associated with them
     # copy this method into collection specific tei_to_es.rb
     # to return specific string or xpath as required
-  end
-
-  def shortname
-    @options["shortname"]
   end
 
   def source

--- a/scripts/ruby/lib/to_es/vra_to_es/fields.rb
+++ b/scripts/ruby/lib/to_es/vra_to_es/fields.rb
@@ -34,6 +34,14 @@ class VraToEs < XmlToEs
     return get_text(@xpaths["creators"])
   end
 
+  def collection
+    @options["es_type"]
+  end
+
+  def collection_desc
+    @options["collection_desc"] || @options["collection"]
+  end
+
   def contributors
     contrib_list = []
     contributors = @xml.xpath(@xpaths["contributors"])
@@ -95,10 +103,6 @@ class VraToEs < XmlToEs
     get_list(@xpaths["places"])
   end
 
-  def collection
-    @options["collection_desc"] || @options["collection"]
-  end
-
   def publisher
     get_list(@xpaths["publisher"])
   end
@@ -120,10 +124,6 @@ class VraToEs < XmlToEs
     # by default collections have no uri associated with them
     # copy this method into collection specific vra_to_es.rb
     # to return specific string or xpath as required
-  end
-
-  def shortname
-    @options["shortname"]
   end
 
   def source


### PR DESCRIPTION
confusingly, there is already an option named "collection" which
is tracking the name of the directory / terminal argument
but I am using es_type / solr_core where possible since those
are more specific for the environment, whereas the directory name
can be different depending on how it was cloned, set up, etc

I would like to revisit this, but trying to finish this so a coworker
can continue work on an API site