### PR TITLE
add recipients nested field per schema doc

### DIFF
--- a/config/api_schema.yml
+++ b/config/api_schema.yml
@@ -84,6 +84,15 @@ properties:
     type: keyword
   source:
     type: keyword
+  recipient:
+    type: nested
+    properties:
+      name:
+        type: keyword
+      id:
+        type: keyword
+      role:
+        type: keyword
   rights_holder:
     type: keyword
   rights:


### PR DESCRIPTION
Cather had been relying on "recipients_k" but moving to using nested field which will accommodate Neihardt, Cody, Cather, Family Letters, and other projects