### PR TITLE
Recipient default behavior and bugfix

### DIFF
--- a/scripts/ruby/lib/helpers.rb
+++ b/scripts/ruby/lib/helpers.rb
@@ -102,8 +102,9 @@ module Common
     string.strip.gsub(/\s+/, " ")
   end
 
-  def self.to_display_text(xml)
+  def self.to_display_text(aXml)
     # sub <corr>.*</corr> for [.*]
+    xml = aXml.dup
     xml.css("corr").each {|e| e.replace("[#{e.text}]") }
     return xml.text
   end

--- a/scripts/ruby/lib/to_es/request.rb
+++ b/scripts/ruby/lib/to_es/request.rb
@@ -89,6 +89,7 @@ class XmlToEs
     @json["person"] = person
     @json["contributor"] = contributor
     @json["creator"] = creator
+    @json["recipient"] = recipient
     # can draw off of container fields
     @json["creator_sort"] = creator_sort
     @json["people"] = people

--- a/scripts/ruby/lib/to_es/tei_to_es/fields.rb
+++ b/scripts/ruby/lib/to_es/tei_to_es/fields.rb
@@ -123,8 +123,10 @@ class TeiToEs < XmlToEs
     get_text(@xpaths["publisher"])
   end
 
-  def recipients
-    get_list(@xpaths["recipients"])
+  def recipient
+    eles = @xml.xpath(@xpaths["recipient"])
+    people = eles.map { |p| { "role" => "recipient", "name" => p.text, "id" => "" } }
+    return people
   end
 
   def rights

--- a/scripts/ruby/lib/to_es/tei_to_es/xpaths.rb
+++ b/scripts/ruby/lib/to_es/tei_to_es/xpaths.rb
@@ -27,7 +27,7 @@ class TeiToEs < XmlToEs
       "person" => "/TEI/teiHeader/profileDesc/textClass/keywords[@n='people']/term",
       "places" => "/TEI/teiHeader/profileDesc/textClass/keywords[@n='places']/term",
       "publisher" => "/TEI/teiHeader/fileDesc/sourceDesc/bibl[1]/publisher[1]",
-      "recipients" => "/TEI/teiHeader/profileDesc/particDesc/person[@role='recipient']/persName",
+      "recipient" => "/TEI/teiHeader/profileDesc/particDesc/person[@role='recipient']/persName",
       "rights_holder" => "/TEI/teiHeader/fileDesc/sourceDesc/msDesc/msIdentifier/repository",
       "source" => "/TEI/teiHeader/fileDesc/sourceDesc/bibl[1]/title[@level='j']",
       "subcategory" => "/TEI/teiHeader/profileDesc/textClass/keywords[@n='subcategory'][1]/term",

--- a/scripts/ruby/lib/to_es/vra_to_es/fields.rb
+++ b/scripts/ruby/lib/to_es/vra_to_es/fields.rb
@@ -120,8 +120,10 @@ class VraToEs < XmlToEs
     get_list(@xpaths["publisher"])
   end
 
-  def recipients
-    # TODO default behavior?
+  def recipient
+    eles = @xml.xpath(@xpaths["recipient"])
+    people = eles.map { |p| { "role" => p["role"], "name" => p.text, "id" => "" } }
+    return people
   end
 
   def rights

--- a/scripts/ruby/lib/to_es/vra_to_es/xpaths.rb
+++ b/scripts/ruby/lib/to_es/vra_to_es/xpaths.rb
@@ -16,6 +16,7 @@ class VraToEs < XmlToEs
       "keywords" => "/vra/work/subjectSet/subject",
       "place" => "/vra/collection[1]/subjectSet[1]/subject/term[@type='geographicPlace']",
       "publisher" => "/vra/work/agentSet/agent",
+      "recipient" => "/TEI/teiHeader/fileDesc/sourceDesc/bibl/persName[@type='addressee']",
       "text" => "/vra",
       "title" => "//title[@type='descriptive']"
     }.merge(override_xpaths)


### PR DESCRIPTION
I suspect that the VRA in particular will need updated default behavior
but in both cases I tried to model the current "person" field as an example

Also found a bug where a helper was altering the xml object being used all over
which hadn't yet caused a problem, but which became apparently when I was
trying to manipulate the XML for the `transcription_t` field