### PR TITLE
quick and dirty es alias scripts for list, add, and delete

### DIFF
--- a/docs/3_manage/aliases.md
+++ b/docs/3_manage/aliases.md
@@ -1,0 +1,40 @@
+## Managing Aliases for Indices
+
+Aliases are convenient ways to refer to a previously named index.  You can change which index an alias is pointing to, but any applications (like an API instance) will follow the alias to the new index, without you having to modify any configuration files.
+
+## Add (and Update) Aliases
+
+Note: the below is hardcoded for localhost
+
+```
+ruby scripts/ruby/es_alias_add.rb -a alias_name -i index_name
+
+```
+
+The above will take that alias, remove any other indices which it might have been pointing to, and then point it at the specified index. **Note: this script does not support multiple indices per alias, and will wipe them out.**
+
+This means that if you already had an index named `test1` with an alias `alias1`, but you ran the following:
+
+```
+ruby scripts/ruby/es_alias_add.rb -a alias1 -i test2
+```
+
+`alias1` would now be pointed at `test2` instead of `test1`
+
+After the script is run, a list of all current aliases per index will be printed out.
+
+## List Aliases
+
+Note: the below is hardcoded for localhost
+
+```
+ruby scripts/ruby/es_alias_list.rb
+```
+
+## Remove Alias
+
+Note: the below is hardcoded for localhost
+
+```
+./scripts/shell/es_delete_alias.sh alias_name
+```

--- a/scripts/ruby/es_alias_add.rb
+++ b/scripts/ruby/es_alias_add.rb
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+
+require "json"
+require "rest-client"
+
+require_relative "lib/parser.rb"
+
+params = Parser.es_alias_add
+# Note: hardcoded path
+es_path = "localhost:9200"
+
+ali = params["alias"]
+idx = params["index"]
+url = "#{es_path}/_aliases"
+
+data = {
+  actions: [
+    { remove: { alias: ali, index: "_all" } },
+    { add: { alias: ali, index: idx } }
+  ]
+}
+
+begin
+  res = RestClient.post(url, data.to_json, { content_type: :json })
+  puts "Results of setting alias #{ali} to index #{idx}"
+  puts res
+  list = JSON.parse(RestClient.get("#{url}"))
+  puts "\nAll aliases: #{JSON.pretty_generate(list)}"
+rescue => e
+  puts "Error: #{e.response}"
+end

--- a/scripts/ruby/es_alias_list.rb
+++ b/scripts/ruby/es_alias_list.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require "json"
+require "rest-client"
+
+# not currently hooked up to configuration file
+# since generally intended to be collection specific
+url = "localhost:9200/_aliases"
+
+res = JSON.parse(RestClient.get(url))
+puts JSON.pretty_generate(res)

--- a/scripts/ruby/lib/parser_options/es_alias_add.rb
+++ b/scripts/ruby/lib/parser_options/es_alias_add.rb
@@ -1,0 +1,43 @@
+module Parser
+  def self.es_alias_add
+    @usage = "Usage: ruby scripts/ruby/es_alias_add.rb -a alias -i index"
+    options = {}
+
+    optparse = OptionParser.new do |opts|
+      opts.banner = @usage
+
+      opts.on( '-h', '--help', 'How does this work?') do
+        puts opts
+        exit
+      end
+
+      options["alias"] = nil
+      opts.on( '-a', '--alias [input]', 'Alias (cdrhapi-v1') do |input|
+        if input && input.length > 0
+          options["alias"] = input
+        else
+          puts "Must specify an alias with -a flag"
+          exit
+        end
+      end
+
+      options["index"] = nil
+      opts.on( '-i', '--index [input]', 'Index (cdrhapi-v1.1') do |input|
+        if input && input.length > 0
+          options["index"] = input
+        else
+          puts "Must specify an index with -i flag"
+          exit
+        end
+      end
+
+    end
+
+    optparse.parse!
+    if options["alias"].nil? || options["index"].nil?
+      puts "must specify alias and index with -a and -i, respectively"
+      exit
+    end
+    options
+  end
+end

--- a/scripts/shell/es_delete_alias.sh
+++ b/scripts/shell/es_delete_alias.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+NAME=$1
+URL="localhost:9200/_all/_alias/"$NAME
+
+curl -XDELETE $URL'?pretty'

--- a/scripts/shell/es_delete_alias.sh
+++ b/scripts/shell/es_delete_alias.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 NAME=$1
-URL="localhost:9200/_all/_alias/"$NAME
+URL="localhost:9200/_all/_alias/${NAME}"
 
-curl -XDELETE $URL'?pretty'
+curl -XDELETE "${URL}?pretty"


### PR DESCRIPTION
chose not to hook into config files for es_path since they're
typically expected to be collection specific, and aliases are not