### PR TITLE
HTML to ES and HTML

### DIFF
--- a/collections/example/.gitignore
+++ b/collections/example/.gitignore
@@ -15,6 +15,10 @@ private.yml
 **/html-generated/*
 **/solr/*
 
+# If you don't want to commit development html, uncomment this line
+
+# output/development/html/*
+
 !**/.keep
 
 .DS_Store

--- a/config/public.yml
+++ b/config/public.yml
@@ -28,13 +28,14 @@ default:
 
   # formats to solr transformation locations
   dc_solr_xsl: scripts/xslt/cdrh_to_solr/solr_transform_dc.xsl
-  vra_solr_xsl: scripts/xslt/cdrh_to_solr/solr_transform_vra.xsl
   tei_solr_xsl: scripts/xslt/cdrh_to_solr/solr_transform_tei.xsl
+  vra_solr_xsl: scripts/xslt/cdrh_to_solr/solr_transform_vra.xsl
 
   # formats to html snippets transformation locations
   dc_html_xsl: scripts/xslt/cdrh_dc_to_html/dublin_core_to_html.xsl
-  vra_html_xsl: scripts/xslt/cdrh_to_html/vra_to_html.xsl
+  html_html_xsl: scripts/xslt/html_to_html/html.xsl
   tei_html_xsl: scripts/xslt/cdrh_to_html/tei.p5.xsl
+  vra_html_xsl: scripts/xslt/cdrh_to_html/vra_to_html.xsl
 
   # file locations
   data_base: https://cdrhmedia.unl.edu

--- a/scripts/ruby/lib/data_manager.rb
+++ b/scripts/ruby/lib/data_manager.rb
@@ -22,6 +22,7 @@ class DataManager
     {
       "csv" => FileCsv,
       "dc" => FileDc,
+      "html" => FileHtml,
       "tei" => FileTei,
       "vra" => FileVra,
       "yml" => FileYml

--- a/scripts/ruby/lib/file_type.rb
+++ b/scripts/ruby/lib/file_type.rb
@@ -172,4 +172,13 @@ class FileType
     JSON.pretty_generate(json)
   end
 
+  def subdoc_xpaths
+    # Override this method per file type in order to add subdocuments
+    # for example:
+    # {
+    #   "/TEI" => TeiToEs,
+    #   "//listPerson/person" => TeiToEsPersonography,
+    # }
+  end
+
 end

--- a/scripts/ruby/lib/file_types/file_html.rb
+++ b/scripts/ruby/lib/file_types/file_html.rb
@@ -1,0 +1,32 @@
+require_relative "../helpers.rb"
+require_relative "../file_type.rb"
+require_relative "../solr_poster.rb"
+require "rest-client"
+
+class FileHtml < FileType
+  attr_reader :es_req
+
+
+  def initialize(file_location, coll_dir, options)
+    super(file_location, coll_dir, options)
+    @script_html = "#{options["repo_dir"]}/#{options["html_html_xsl"]}"
+  end
+
+  # if there should not be any html transformation taking place
+  # then leave this method empty but uncommented to override default behavior
+
+  # if you would like to use the default transformation behavior
+  # then comment or remove both of the following methods!
+
+  def transform_es
+    raise "HTML to ES transformation not supported"
+  end
+
+  # def transform_html
+  #   raise "HTML to HTML transformation not supported"
+  # end
+
+  def transform_solr
+    raise "HTML to Solr transformation not supported"
+  end
+end

--- a/scripts/ruby/lib/file_types/file_html.rb
+++ b/scripts/ruby/lib/file_types/file_html.rb
@@ -12,15 +12,21 @@ class FileHtml < FileType
     @script_html = "#{options["repo_dir"]}/#{options["html_html_xsl"]}"
   end
 
+  def subdoc_xpaths
+    # Override this method per file type in order to add subdocuments
+    # for example:
+    { "/" => HtmlToEs }
+  end
+
   # if there should not be any html transformation taking place
   # then leave this method empty but uncommented to override default behavior
 
   # if you would like to use the default transformation behavior
   # then comment or remove both of the following methods!
 
-  def transform_es
-    raise "HTML to ES transformation not supported"
-  end
+  # def transform_es
+  #   raise "HTML to ES transformation not supported"
+  # end
 
   # def transform_html
   #   raise "HTML to HTML transformation not supported"

--- a/scripts/ruby/lib/parser_options/post.rb
+++ b/scripts/ruby/lib/parser_options/post.rb
@@ -22,12 +22,12 @@ module Parser
 
       # default to no restricted format
       options["format"] = nil
-      opts.on( '-f', '--format [input]', 'Restrict to one format (tei, csv, dublin_core, vra)') do |input|
-        if input == "tei" || input == "csv" || input == "dublin_core" || input == "vra"
+      opts.on( '-f', '--format [input]', 'Restrict to one format (csv, dublin_core, html, tei, vra)') do |input|
+        if %w[csv dublic_core html tei vra].include?(input)
           options["format"] = input
         else
           puts "Format #{input} is not recognized.".red
-          puts "Allowed formats are tei, csv, vra, and dublin_core"
+          puts "Allowed formats are csv, dublic_core, html, tei, and vra"
           exit
         end
       end

--- a/scripts/ruby/lib/requirer.rb
+++ b/scripts/ruby/lib/requirer.rb
@@ -5,6 +5,8 @@ require_relative "parser.rb"
 
 current_dir = File.expand_path(File.dirname(__FILE__))
 
+require_relative "to_es/html_to_es.rb"
+
 require_relative "to_es/tei_to_es.rb"
 require_relative "to_es/tei_to_es/tei_to_es_personography.rb"
 

--- a/scripts/ruby/lib/to_es/html_to_es.rb
+++ b/scripts/ruby/lib/to_es/html_to_es.rb
@@ -1,0 +1,33 @@
+require_relative "xml_to_es.rb"
+require_relative "html_to_es/fields.rb"
+require_relative "html_to_es/request.rb"
+require_relative "html_to_es/xpaths.rb"
+
+###########################################################
+# NOTE:  DO NOT EDIT html_to_ES FILES IN SCRIPTS DIRECTORY #
+###########################################################
+
+#   (unless you are a CDRH dev and then you may do so very cautiously)
+#   this file provides defaults for ALL of the collections included
+#   in the API and changing it could alter dozens of sites unexpectedly!
+# PLEASE RUN LOADS OF TESTS AFTER A CHANGE BEFORE PUSHING TO PRODUCTION
+
+# HOW DO I CHANGE XPATHS?
+#   You may add or modify xpaths in each collection's html_to_es.rb file
+#   located in the collections/<collection>/scripts directory
+
+# HOW DO I CHANGE FIELD CONTENT?
+#   You may need to alter an xpath, but otherwise you may also
+#   copy paste the field defined in html_to_es/fields.rb and change
+#   it as needed. If you are dealing with something particularly complex
+#   you may need to consult with a CDRH dev for help
+
+# HOW DO I CUSTOMIZE THE FIELDS BEING SENT TO ELASTICSEARCH?
+#   You will need to look in the html_to_es/request.rb file, which has
+#   collections of fields being sent to elasticsearch
+#   you can override individual chunks of fields in your collection
+
+class HtmlToEs < XmlToEs
+  # Override XmlToEs methods that need to be customized for TEI here
+  # rather than in one of the files in html_to_es/
+end

--- a/scripts/ruby/lib/to_es/html_to_es/fields.rb
+++ b/scripts/ruby/lib/to_es/html_to_es/fields.rb
@@ -23,11 +23,9 @@ class HtmlToEs < XmlToEs
     # category = get_text(@xpaths["category"])
   end
 
-  # note this does not sort the creators
+  # nested field
   def creator
     # TODO
-    # creators = get_list(@xpaths["creators"])
-    # return creators.map { |creator| { "name" => CommonXml.normalize_space(creator) } }
   end
 
   # returns ; delineated string of alphabetized creators
@@ -48,7 +46,6 @@ class HtmlToEs < XmlToEs
   end
 
   def data_type
-    # TODO ?
     "html"
   end
 
@@ -139,8 +136,6 @@ class HtmlToEs < XmlToEs
     text = []
     body = get_text(@xpaths["text"], false)
     text << body
-    # TODO: do we need to preserve tags like <i> in text? if so, turn get_text to true
-    # text << CommonXml.convert_tags_in_string(body)
     text += text_additional
     return CommonXml.normalize_space(text.join(" "))
   end

--- a/scripts/ruby/lib/to_es/html_to_es/fields.rb
+++ b/scripts/ruby/lib/to_es/html_to_es/fields.rb
@@ -1,0 +1,192 @@
+class HtmlToEs < XmlToEs
+  # Note to add custom fields, use "assemble_collection_specific" from request.rb
+  # and be sure to either use the _d, _i, _k, or _t to use the correct field type
+
+  ##########
+  # FIELDS #
+  ##########
+
+  def id
+    @id
+  end
+
+  def id_dc
+    # TODO use api path from config or something?
+    "https://cdrhapi.unl.edu/doc/#{@id}"
+  end
+
+  def annotations_text
+    # TODO what should default behavior be?
+  end
+
+  def category
+    # category = get_text(@xpaths["category"])
+  end
+
+  # note this does not sort the creators
+  def creator
+    # TODO
+    # creators = get_list(@xpaths["creators"])
+    # return creators.map { |creator| { "name" => CommonXml.normalize_space(creator) } }
+  end
+
+  # returns ; delineated string of alphabetized creators
+  def creator_sort
+    # get_text(@xpaths["creators"])
+  end
+
+  def collection
+    @options["es_type"]
+  end
+
+  def collection_desc
+    @options["collection_desc"] || @options["es_type"]
+  end
+
+  def contributor
+    # TODO
+  end
+
+  def data_type
+    # TODO ?
+    "html"
+  end
+
+  def date(before=true)
+    # TODO
+  end
+
+  def date_display
+    # TODO
+  end
+
+  def description
+    # Note: override per collection as needed
+  end
+
+  def format
+    # TODO
+  end
+
+  def image_id
+    # TODO
+  end
+
+  def keywords
+    get_list(@xpaths["keywords"])
+  end
+
+  def language
+    # TODO
+  end
+
+  def medium
+    # Default behavior is the same as "format" method
+    format
+  end
+
+  def person
+    # TODO
+  end
+
+  def people
+    # TODO
+  end
+
+  def places
+    # get_list(@xpaths["places"])
+  end
+
+  def publisher
+    # get_text(@xpaths["publisher"])
+  end
+
+  def recipient
+    # TODO
+  end
+
+  def rights
+    # Note: override by collection as needed
+    "All Rights Reserved"
+  end
+
+  def rights_holder
+    # get_text(@xpaths["rights_holder"])
+  end
+
+  def rights_uri
+    # by default collections have no uri associated with them
+    # copy this method into collection specific tei_to_es.rb
+    # to return specific string or xpath as required
+  end
+
+  def source
+    # get_text(@xpaths["source"])
+  end
+
+  def subjects
+    # TODO default behavior?
+  end
+
+  def subcategory
+    # subcategory = get_text(@xpaths["subcategory"])
+    # subcategory.length > 0 ? subcategory : "none"
+  end
+
+  def text
+    # handling separate fields in array
+    # means no worrying about handling spacing between words
+    text = []
+    body = get_text(@xpaths["text"], false)
+    text << body
+    # TODO: do we need to preserve tags like <i> in text? if so, turn get_text to true
+    # text << CommonXml.convert_tags_in_string(body)
+    text += text_additional
+    return CommonXml.normalize_space(text.join(" "))
+  end
+
+  def text_additional
+    # Note: Override this per collection if you need additional
+    # searchable fields or information for collections
+    # just make sure you return an array at the end!
+
+    # text = []
+    # text << your_new_fields_and_stuff
+    # return text
+    return []
+  end
+
+  def title
+    get_text(@xpaths["titles"])
+  end
+
+  def title_sort
+    t = title
+    CommonXml.normalize_name(t)
+  end
+
+  def topics
+    # TODO
+  end
+
+  def uri
+    # override per collection
+    # should point at the live website view of resource
+  end
+
+  def uri_data
+    base = @options["data_base"]
+    subpath = "data/#{@options["collection"]}/tei"
+    "#{base}/#{subpath}/#{@id}.xml"
+  end
+
+  def uri_html
+    base = @options["data_base"]
+    subpath = "data/#{@options["collection"]}/output/#{@options["environment"]}/html"
+    "#{base}/#{subpath}/#{@id}.html"
+  end
+
+  def works
+    # TODO
+  end
+end

--- a/scripts/ruby/lib/to_es/html_to_es/request.rb
+++ b/scripts/ruby/lib/to_es/html_to_es/request.rb
@@ -1,0 +1,7 @@
+class HtmlToEs < XmlToEs
+
+  # please refer to generic xml to es request file, request.rb
+  # and override methods specific to HTML transformation here
+  # project specific overrides should go in the COLLECTION's overrides!
+
+end

--- a/scripts/ruby/lib/to_es/html_to_es/xpaths.rb
+++ b/scripts/ruby/lib/to_es/html_to_es/xpaths.rb
@@ -1,0 +1,29 @@
+class HtmlToEs < XmlToEs
+  # These are the default xpaths that are used for collections
+  #  if you require a different xpath, please override the xpath in
+  #  the specific collection's TeiToEs file or create a new method
+  #  in that file which returns a different value
+  def xpaths_list
+    {
+      "category" => "",
+      "contributors" => "",
+      "creators" => "",
+      "date" => "",
+      "formats" => "",
+      "keywords" => "//meta[@name='dc.keywords']",
+      # note: language is global attribute xml:lang
+      "language" => "//meta[@name='dc.language']",
+      "person" => "",
+      "places" => "",
+      "publisher" => "",
+      "recipient" => "",
+      "rights_holder" => "",
+      "source" => "",
+      "subcategory" => "",
+      "text" => "//body",
+      "titles" => "//title",
+      "topic" => "",
+      "works" => "",
+    }.merge(override_xpaths)
+  end
+end

--- a/scripts/xslt/html_to_html/html.xsl
+++ b/scripts/xslt/html_to_html/html.xsl
@@ -5,6 +5,10 @@
   <xsl:output indent="yes" omit-xml-declaration="yes"/>
 
   <!-- <xsl:param name="slug"/> -->
+  <xsl:param name="collection"/>
+  <xsl:param name="data_base"/>
+  <xsl:param name="media_base"/>
+  <xsl:param name="environment"/>
 
   <xsl:template match="/" exclude-result-prefixes="#all">
 

--- a/scripts/xslt/html_to_html/html.xsl
+++ b/scripts/xslt/html_to_html/html.xsl
@@ -1,0 +1,21 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+  xpath-default-namespace="http://www.tei-c.org/ns/1.0"
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <xsl:output indent="yes" omit-xml-declaration="yes"/>
+
+  <!-- <xsl:param name="slug"/> -->
+
+
+  <xsl:template match="/" exclude-result-prefixes="#all">
+
+    <xsl:variable name="filename" select="tokenize(base-uri(.), '/')[last()]"/>
+    <!-- The part of the url after the main document structure and before the filename.
+      Collected so we can link to files, even if they are nested, i.e. whitmanarchive/manuscripts -->
+
+    <!-- Split the filename using '\.' -->
+    <xsl:variable name="filenamepart" select="substring-before($filename, '.xml')"/>
+    <xsl:copy-of select="."/>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Adds support for plain HTML documents both being added to elasticsearch
as well as to be transformed into other HTML

The HTML to HTML XSL is very basic at the moment until I have examples to work with.
HTML to ES will either always be highly customized or we will need to come up with a standard
template for those projects which wish to use HTML