### PR TITLE
elasticsearch 6

### DIFF
--- a/collections/example/config/public.yml
+++ b/collections/example/config/public.yml
@@ -1,7 +1,9 @@
 default:
   shortname: example
+  # collection replaces es_type
+  # the directory name will be used if collection is omitted here
+  collection: example
   collection_desc: Example Data Repository
-  es_type: example
   solr_core: there_is_no_solr_core
 
   variables_html:

--- a/collections/example/config/public.yml
+++ b/collections/example/config/public.yml
@@ -1,6 +1,5 @@
 default:
   shortname: example
-  # collection replaces es_type
   # the directory name will be used if collection is omitted here
   collection: example
   collection_desc: Example Data Repository

--- a/config/private.example.yml
+++ b/config/private.example.yml
@@ -3,9 +3,7 @@ default:
   es_path: http://localhost:9200
   # Note: override es_index as necessary per collection / environment
   # in order to push to API vs collection testing index, etc
-  # this is NOT the "type" of an elasticsearch index
   es_index: test1
-  es_type: collection
 
 ###################
 #   Development   #

--- a/scripts/ruby/es_clear_index.rb
+++ b/scripts/ruby/es_clear_index.rb
@@ -5,7 +5,7 @@ require_relative "lib/requirer.rb"
 def confirm_basic(options, url)
   # verify that the user is really sure about the index they're about to wipe
   puts "Are you sure that you want to remove entries from"
-  puts " #{options["es_type"]}'s #{options['environment']} environment?"
+  puts " #{options["collection"]}'s #{options['environment']} environment?"
   puts "url: #{url}"
   puts "y/N"
   answer = STDIN.gets.chomp
@@ -18,8 +18,8 @@ def main
 
   # run the parameters through the option parser
   params = Parser.clear_index_params
-  options = Options.new(params, "#{this_dir}/../../config", "#{this_dir}/../../collections/#{params['collection']}/config").all
-  if params["collection"] == "all"
+  options = Options.new(params, "#{this_dir}/../../config", "#{this_dir}/../../collections/#{params['collection_dir']}/config").all
+  if params["collection_dir"] == "all"
     clear_all(options)
   else
     clear_index(options)
@@ -31,22 +31,30 @@ def build_data(options)
     field = options["field"] || "identifier"
     return {
       "query" => {
-        "regexp" => { field => options["regex"] }
+        "bool" => {
+          "must" => [
+            { "regexp" => { field => options["regex"] } },
+            { "term" => { "collection" => options["collection"] } }
+          ]
+        }
       }
     }
   else
     return {
-      "query" => { "match_all" => {} }
+      "query" => { "term" => { "collection" => options["collection"] } }
     }
   end
 end
 
 def clear_all(options)
-  puts "Please verify that you want to clear EVERY ENTRY from the ENTIRE INDEX"
+  puts "Please verify that you want to clear EVERY ENTRY from the ENTIRE INDEX\n\n"
+  puts "== FIELD / REGEX FILTERS NOT AVAILABLE FOR THIS OPTION, YOU'LL WIPE EVERYTHING ==\n\n"
+  puts "Seriously, you probably do not want to do this"
+  puts "Are you running this on something other than your local machine?  RETHINK IT."
   puts "Type: 'Yes I'm sure'"
   confirm = STDIN.gets.chomp
   if confirm == "Yes I'm sure"
-    url = "#{options["es_path"]}/#{options["es_index"]}/_delete_by_query?pretty"
+    url = "#{options["es_path"]}/#{options["es_index"]}/_doc/_delete_by_query?pretty"
     post url, { "query" => { "match_all" => {} } }
   else
     puts "You typed '#{confirm}'. This is incorrect, exiting program"
@@ -55,7 +63,7 @@ def clear_all(options)
 end
 
 def clear_index(options)
-  url = "#{options["es_path"]}/#{options["es_index"]}/#{options["es_type"]}/_delete_by_query?pretty"
+  url = "#{options["es_path"]}/#{options["es_index"]}/_doc/_delete_by_query?pretty"
   confirmation = confirm_basic(options, url)
 
   if confirmation

--- a/scripts/ruby/es_clear_index.rb
+++ b/scripts/ruby/es_clear_index.rb
@@ -54,7 +54,7 @@ def clear_all(options)
   puts "Type: 'Yes I'm sure'"
   confirm = STDIN.gets.chomp
   if confirm == "Yes I'm sure"
-    url = "#{options["es_path"]}/#{options["es_index"]}/_doc/_delete_by_query?pretty"
+    url = "#{options["es_path"]}/#{options["es_index"]}/_doc/_delete_by_query?pretty=true"
     post url, { "query" => { "match_all" => {} } }
   else
     puts "You typed '#{confirm}'. This is incorrect, exiting program"
@@ -63,7 +63,7 @@ def clear_all(options)
 end
 
 def clear_index(options)
-  url = "#{options["es_path"]}/#{options["es_index"]}/_doc/_delete_by_query?pretty"
+  url = "#{options["es_path"]}/#{options["es_index"]}/_doc/_delete_by_query?pretty=true"
   confirmation = confirm_basic(options, url)
 
   if confirmation

--- a/scripts/ruby/es_get_schema.rb
+++ b/scripts/ruby/es_get_schema.rb
@@ -13,7 +13,7 @@ options = Options.new(params, "#{this_dir}/../../config", "#{this_dir}/../../col
 begin
   idx = options["es_index"]
 
-  url = "#{options["es_path"]}/#{idx}/_mapping/_doc?pretty"
+  url = "#{options["es_path"]}/#{idx}/_mapping/_doc?pretty=true"
   puts "environment: #{options["environment"]}"
   res = RestClient.get(url)
   puts res.body

--- a/scripts/ruby/es_get_schema.rb
+++ b/scripts/ruby/es_get_schema.rb
@@ -8,13 +8,12 @@ require_relative "lib/parser.rb"
 this_dir = File.dirname(__FILE__)
 
 params = Parser.es_set_schema_params
-options = Options.new(params, "#{this_dir}/../../config", "#{this_dir}/../../collections/#{params['collection']}/config").all
+options = Options.new(params, "#{this_dir}/../../config", "#{this_dir}/../../collections/#{params['collection_dir']}/config").all
 
 begin
   idx = options["es_index"]
-  type = options["es_type"]
 
-  url = "#{options["es_path"]}/#{idx}/_mapping/#{type}?pretty"
+  url = "#{options["es_path"]}/#{idx}/_mapping/_doc?pretty"
   puts "environment: #{options["environment"]}"
   res = RestClient.get(url)
   puts res.body

--- a/scripts/ruby/es_set_schema.rb
+++ b/scripts/ruby/es_set_schema.rb
@@ -9,13 +9,12 @@ this_dir = File.dirname(__FILE__)
 
 params = Parser.es_set_schema_params
 schema = YAML.load_file("config/api_schema.yml")
-options = Options.new(params, "#{this_dir}/../../config", "#{this_dir}/../../collections/#{params['collection']}/config").all
+options = Options.new(params, "#{this_dir}/../../config", "#{this_dir}/../../collections/#{params['collection_dir']}/config").all
 
 begin
   idx = options["es_index"]
-  type = options["es_type"]
 
-  url = "#{options["es_path"]}/#{idx}/_mapping/#{type}?pretty&update_all_types"
+  url = "#{options["es_path"]}/#{idx}/_mapping/_doc?pretty"
   puts "environment: #{options["environment"]}"
   puts "Setting schema: #{url}"
   RestClient.put(url, schema.to_json, { :content_type => :json })

--- a/scripts/ruby/lib/data_manager.rb
+++ b/scripts/ruby/lib/data_manager.rb
@@ -209,7 +209,7 @@ class DataManager
     if should_transform?("es") && !@options["transform_only"]
       schema = YAML.load_file("#{@repo_dir}/#{@options["es_schema_path"]}")
       path, idx = ["es_path", "es_index"].map { |i| @options[i] }
-      url = "#{path}/#{idx}/_mapping/_doc?pretty"
+      url = "#{path}/#{idx}/_mapping/_doc?pretty=true"
       begin
         RestClient.put(url, schema.to_json, { content_type: :json })
         msg = "Successfully set elasticsearch schema for index #{idx} _doc"

--- a/scripts/ruby/lib/file_type.rb
+++ b/scripts/ruby/lib/file_type.rb
@@ -49,13 +49,12 @@ class FileType
     if transformed && transformed.length > 0
       transformed.each do |doc|
         id = doc["identifier"]
-        type = @options["es_type"]
         puts "posting #{id}"
-        puts "PATH: #{url}/#{type}/#{id}" if options["verbose"]
+        puts "PATH: #{url}/_doc/#{id}" if options["verbose"]
         # NOTE: If you need to do partial updates rather than replacement of doc
         # you will need to add _update at the end of this URL
         begin
-          RestClient.put("#{url}/#{type}/#{id}", doc.to_json, {:content_type => :json } )
+          RestClient.put("#{url}/_doc/#{id}", doc.to_json, {:content_type => :json } )
         rescue => e
           return { "error" => "Error transforming or posting to ES for #{self.filename(false)}: #{e.response}" }
         end

--- a/scripts/ruby/lib/options.rb
+++ b/scripts/ruby/lib/options.rb
@@ -7,13 +7,15 @@ class Options
 
   def initialize(params, general_config_path, collection_config_path)
     @directory = File.dirname(__FILE__)
-    @collection_dir = params["collection"]
+    @collection_dir = params["collection_dir"]
     @environment = params["environment"]
 
     # read and store raw config files
     read_all_configs(general_config_path, collection_config_path)
     # make a smushed version that overrides like this: general < collection < user specified
     @all = smash_configs.merge!(params)
+    # if collection is not specifically set in the configs, then default to the directory name
+    @all["collection"] = params["collection_dir"] if !@all.key?("collection")
   end
 
   def print_message(variable, name)
@@ -52,13 +54,13 @@ class Options
     new_config = {}
     if config
       # add the default settings
-      if config.has_key?("default")
+      if config.key?("default")
         config["default"].each do |key, value|
           new_config[key] = value
         end
       end
       # add the environment settings and override default as needed
-      if config.has_key?(@environment)
+      if config.key?(@environment)
         config[@environment].each do |key, value|
           new_config[key] = value
         end

--- a/scripts/ruby/lib/parser.rb
+++ b/scripts/ruby/lib/parser.rb
@@ -9,23 +9,23 @@ Dir["#{File.expand_path(File.dirname(__FILE__))}/parser_options/*.rb"].each {|f|
 #####################
 
 module Parser
-  def self.argv_collections(argv)
-    collection = nil
+  def self.argv_collection_dir(argv)
+    collection_dir = nil
     # put this after calling parse! on the incoming option flags
     # or the flags will be picked up as args also
     if argv.length == 0
-      puts "Crisis! Oh no! You must specify a collection that you want to post!".red
+      puts "Crisis! Oh no! You must specify the collection directory whose contents you wish to post!".red
       puts @usage
       exit
     elsif argv.length == 1
-      collection = argv[0]
+      collection_dir = argv[0]
     else
       # they entered too many collections! (or something else is terribly wrong)
-      puts "Captain, sensors detect more than one collection requested!".red
+      puts "Captain, sensors detect more than one collection directory requested!".red
       puts @usage
       exit
     end
-    return collection
+    return collection_dir
   end
 
   # take a string in utc and create a time object with it

--- a/scripts/ruby/lib/parser_options/clear_index.rb
+++ b/scripts/ruby/lib/parser_options/clear_index.rb
@@ -34,7 +34,7 @@ module Parser
     # magic
     optparse.parse!
 
-    options["collection"] = argv_collections(ARGV)
+    options["collection_dir"] = argv_collection_dir(ARGV)
 
     return options
   end # ends clear_index_params

--- a/scripts/ruby/lib/parser_options/es_set_schema.rb
+++ b/scripts/ruby/lib/parser_options/es_set_schema.rb
@@ -21,7 +21,7 @@ module Parser
     end
 
     optparse.parse!
-    options["collection"] = Parser.argv_collections(ARGV)
+    options["collection_dir"] = Parser.argv_collection_dir(ARGV)
     return options
   end
 end

--- a/scripts/ruby/lib/parser_options/post.rb
+++ b/scripts/ruby/lib/parser_options/post.rb
@@ -84,7 +84,7 @@ module Parser
 
     # magic
     optparse.parse!
-    options["collection"] = Parser.argv_collections(ARGV)
+    options["collection_dir"] = Parser.argv_collection_dir(ARGV)
 
     return options
   end

--- a/scripts/ruby/lib/to_es/html_to_es/fields.rb
+++ b/scripts/ruby/lib/to_es/html_to_es/fields.rb
@@ -34,11 +34,11 @@ class HtmlToEs < XmlToEs
   end
 
   def collection
-    @options["es_type"]
+    @options["collection"]
   end
 
   def collection_desc
-    @options["collection_desc"] || @options["es_type"]
+    @options["collection_desc"] || @options["collection"]
   end
 
   def contributor

--- a/scripts/ruby/lib/to_es/tei_to_es/fields.rb
+++ b/scripts/ruby/lib/to_es/tei_to_es/fields.rb
@@ -36,11 +36,11 @@ class TeiToEs < XmlToEs
   end
 
   def collection
-    @options["es_type"]
+    @options["collection"]
   end
 
   def collection_desc
-    @options["collection_desc"] || @options["es_type"]
+    @options["collection_desc"] || @options["collection"]
   end
 
   def contributor
@@ -86,6 +86,7 @@ class TeiToEs < XmlToEs
   end
 
   def image_id
+    # Note: don't pull full path because will be pulled by IIIF
     images = get_list(@xpaths["image_id"])
     images[0] if images
   end

--- a/scripts/ruby/lib/to_es/tei_to_es/xpaths.rb
+++ b/scripts/ruby/lib/to_es/tei_to_es/xpaths.rb
@@ -23,7 +23,7 @@ class TeiToEs < XmlToEs
         "periodical" => "/TEI/teiHeader/fileDesc/sourceDesc/bibl/title[@level='j']",
         "manuscript" => "/TEI/teiHeader/fileDesc/sourceDesc/bibl/title[@level='m']"
       },
-      "image_id" => "/TEI/text//pb/@facs[1]",
+      "image_id" => "/TEI/text//pb/@facs",
       "keywords" => "/TEI/teiHeader/profileDesc/textClass/keywords[@n='keywords']/term",
       # note: language is global attribute xml:lang
       "language" => "(//@lang)[1]",

--- a/scripts/ruby/lib/to_es/vra_to_es/fields.rb
+++ b/scripts/ruby/lib/to_es/vra_to_es/fields.rb
@@ -35,7 +35,7 @@ class VraToEs < XmlToEs
   end
 
   def collection
-    @options["es_type"]
+    @options["collection"]
   end
 
   def collection_desc

--- a/scripts/shell/es_clear_index.sh
+++ b/scripts/shell/es_clear_index.sh
@@ -1,7 +1,7 @@
 NAME=$1
 URL="localhost:9200/"$NAME
 
-curl -XPOST $URL'/_delete_by_query' -d '{
+curl -XPOST $URL'/_delete_by_query' -H 'Content-Type: application/json' -d '{
     "query" : { 
         "match_all" : {}
     }

--- a/scripts/shell/es_create_index.sh
+++ b/scripts/shell/es_create_index.sh
@@ -1,5 +1,5 @@
 NAME=$1
 FULL_URL="localhost:9200/"$NAME
 
-curl -XPUT $FULL_URL"?pretty&pretty"
-curl -XGET 'localhost:9200/_cat/indices?v&pretty'
+curl -XPUT $FULL_URL"?pretty=true"
+curl -XGET 'localhost:9200/_cat/indices?v&pretty=true'

--- a/scripts/shell/es_delete_alias.sh
+++ b/scripts/shell/es_delete_alias.sh
@@ -3,4 +3,4 @@
 NAME=$1
 URL="localhost:9200/_all/_alias/${NAME}"
 
-curl -XDELETE "${URL}?pretty"
+curl -XDELETE "${URL}?pretty=true"

--- a/scripts/shell/es_delete_index.sh
+++ b/scripts/shell/es_delete_index.sh
@@ -1,4 +1,4 @@
 NAME=$1
 URL="localhost:9200/"$NAME
 
-curl -XDELETE $URL'?pretty'
+curl -XDELETE $URL'?pretty=true'

--- a/scripts/shell/es_prune_null_collections.sh
+++ b/scripts/shell/es_prune_null_collections.sh
@@ -5,7 +5,7 @@
 # (these documents do not appear in the API at /collections, but are listed at /items)
 
 NAME=$1
-URL="localhost:9200/${NAME}/_delete_by_query?pretty"
+URL="localhost:9200/${NAME}/_delete_by_query?pretty=true"
 
 curl -X POST $URL -H 'Content-Type: application/json' -d'
 {

--- a/scripts/shell/es_prune_null_collections.sh
+++ b/scripts/shell/es_prune_null_collections.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# specify index name
+# this script deletes all documents which do not have a collection name
+# (these documents do not appear in the API at /collections, but are listed at /items)
+
+NAME=$1
+URL="localhost:9200/${NAME}/_delete_by_query?pretty"
+
+curl -X POST $URL -H 'Content-Type: application/json' -d'
+{
+  "query": {
+    "bool": {
+      "must_not" : {
+        "exists" : {
+          "field" : "collection"
+        }
+      }
+    }
+  }
+}
+'

--- a/scripts/shell/es_test_item.sh
+++ b/scripts/shell/es_test_item.sh
@@ -2,11 +2,13 @@
 # POST
 #  path to elasticsearch (localhost:9200)
 #  index name (test_)
-#  collection name / _type (type1)
 #  id of item (1)
 #  put in JSON for item
 
-curl -XPOST 'localhost:9200/test/type1/1?pretty'  -d'
+# DO NOT RUN THIS AGAINST ANY INDEXES YOU CARE ABOUT
+# IT WILL CREATE A NEW KEYWORD FIELD MAPPING
+
+curl -XPOST 'localhost:9200/test/_doc/1?pretty=true' -H 'Content-Type: application/json' -d'
 {
     "stuff": "something"
 }

--- a/test/collection_test.rb
+++ b/test/collection_test.rb
@@ -41,7 +41,6 @@ require_relative "classes.rb"
 #           options = {
 #             "environment" => "test",
 #             "collection" => collection,
-#             "es_type" => collection,
 #           }
 #           tei = FileTei.new(path, "#{collections_dir}/#{collection}", options)
 #           res = tei.transform_es

--- a/test/tei_to_es_test.rb
+++ b/test/tei_to_es_test.rb
@@ -14,7 +14,7 @@ class TeiToEsTest < Minitest::Test
     # should return a json object with a few keys
     # but will be testing values more in collection specific test suite
     json = @teitoes.assemble_json
-    assert_equal 38, json.length
+    assert_equal 39, json.length
   end
 
   def test_get_list


### PR DESCRIPTION
**This is incompatible with https://github.com/CDRH/api/releases/tag/v1.0.0**

Major revision which removes `_type` to correspond with elasticsearch 5 to 6 updates
Now uses `_doc` for type mapping and relies on `collection` keyword field
the "collection" parameter has been renamed `collection_dir` to prevent confusion
  - the "mini data" directory housing each collection is the `collection_dir`
  - the `collection` option is what is being stored in elasticsearch
  - this unlinks the dependency between the directory name and the collection being the same
  - this should help with being able to name it different things in different places

I also got into a bit of trouble while I was writing this by sending documents that had NO collection
Turns out I probably could have run the same ids with a real collection to update the documents, of course
But instead I took the time to figure out how to wipe null fields so anyway, you're welcome world

Fixes minor test blip