### PR TITLE
Set default prod status as non-public, add override option

### DIFF
--- a/lib/datura/python/api_fields.py
+++ b/lib/datura/python/api_fields.py
@@ -202,6 +202,9 @@ def add_formatted_value(ctx, item, key, value, datatype, label=""):
     }
     formatted = ctx.client.prepare_property_value(prop_value, prop_id, label)
 
+    if key in ctx.fields.private_fields():
+        formatted["is_public"] = False
+
     if key in item and isinstance(item[key],list):
         item[key].append(formatted)
     else:

--- a/lib/datura/python/field_definitions.py
+++ b/lib/datura/python/field_definitions.py
@@ -30,6 +30,18 @@ class FieldDefinitions:
         # Stored as a private attribute and accessed only by uriData().
         self._omeka_data_base = omeka_data_base
 
+    def private_fields(self):
+        """
+        Return a set of Omeka property terms whose values should be posted with
+        is_public=False. Override in field_overrides.py to mark specific fields
+        as private for this collection.
+
+        Example:
+            def private_fields(self):
+                return {"dcterms:identifier", "dcterms:source"}
+        """
+        return set()
+
     def field_manifest(self):
         """
         Declare the ordered list of Omeka property mappings for this collection.

--- a/lib/datura/python/field_overrides_example.py
+++ b/lib/datura/python/field_overrides_example.py
@@ -38,3 +38,9 @@ class CustomFields(FieldDefinitions):
     #         return datetime.strptime(date_to_parse, "%Y-%m-%d").year
     #     else:
     #         return date_to_parse
+
+    # Pattern 6: mark specific metadata fields as private at the value level
+    # values for these terms will be posted with is_public: false in the Omeka S API payload,
+    # hiding them from public view regardless of item-level visibility
+    # def private_fields(self):
+    #     return {"dcterms:identifier", "dcterms:source"}

--- a/lib/datura/python/omeka_context.py
+++ b/lib/datura/python/omeka_context.py
@@ -502,13 +502,16 @@ class OmekaContext:
     def is_public(self):
         # type: () -> bool
         """
-        True only when environment is "production".
+        Always returns False. Items are posted as private (visible only to logged-in Omeka
+        admins) regardless of environment. Visibility can be changed manually in the Omeka S
+        admin interface after ingest if needed. 
 
-        Items created with is_public=False are visible only to logged-in Omeka
-        admins, which prevents in-progress development ingests from appearing
-        to public users of the site.
+        If it is desired to change this behavior at some future point such that items posted 
+        to the production environment will be public by default, replace `return False` below 
+        with `return self.environment == "production"`.
+
         """
-        return self.environment == "production"
+        return False
 
     # -----------------------------------------------------------------------
     # API helpers


### PR DESCRIPTION
New items posted to production should be set to `is_public: false`. This PR also introduces a new override option so that individual metadata fields can be set to non-public as needed. 